### PR TITLE
Implement SaveSyncs, Server Favorite, RoomCheck

### DIFF
--- a/NetplayInputPlugin/NetplayInputPlugin.vcxproj
+++ b/NetplayInputPlugin/NetplayInputPlugin.vcxproj
@@ -149,6 +149,15 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release (Server)|x64'">
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
+  <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <VcpkgUseStatic>true</VcpkgUseStatic>
+  </PropertyGroup>
+  <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Release (Server)|Win32'">
+    <VcpkgUseStatic>true</VcpkgUseStatic>
+  </PropertyGroup>
+  <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <VcpkgUseStatic>true</VcpkgUseStatic>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
@@ -467,6 +476,5 @@ echo #define APP_NAME_AND_VERSION "AQZ NetPlay v%COUNT% (%COMMIT%%DIRTY%)" &gt;&
     </Xml>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <ImportGroup Label="ExtensionTargets">
-  </ImportGroup>
+  <ImportGroup Label="ExtensionTargets" />
 </Project>

--- a/NetplayInputPlugin/client.h
+++ b/NetplayInputPlugin/client.h
@@ -15,11 +15,16 @@ class client: public service_wrapper, public connection {
     public:
         client(std::shared_ptr<client_dialog> dialog);
         ~client();
+        void add_server(std::string& server);
+        void remove_server(std::string& server);
         void load_public_server_list();
         void ping_public_server_list();
         std::string get_name();
+        std::string get_favorite_server();
         void set_name(const std::string& name);
         void set_rom_info(const rom_info& rom);
+        void set_save_info(const std::string& save_path);
+        void set_favorite_server(const std::string& fav_server);
         void set_src_controllers(CONTROL controllers[4]);
         void set_dst_controllers(CONTROL controllers[4]);
         void process_input(std::array<BUTTONS, 4>& input);
@@ -42,6 +47,7 @@ class client: public service_wrapper, public connection {
         std::string host;
         uint16_t port;
         std::string path;
+        std::string save_path;
         std::shared_ptr<user_info> me = std::make_shared<user_info>();
         std::vector<std::shared_ptr<user_info>> user_map = { me };
         std::vector<std::shared_ptr<user_info>> user_list = { me };
@@ -71,6 +77,7 @@ class client: public service_wrapper, public connection {
         void set_golf_mode(bool golf);
         void send_join(const std::string& room);
         void send_name();
+        void send_save_info();
         void send_controllers();
         void send_message(const std::string& message);
         void send_start_game();
@@ -79,5 +86,13 @@ class client: public service_wrapper, public connection {
         void send_hia_input(const input_data& input);
         void send_autolag(int8_t value = -1);
         void send_input_map(input_map map);
-        void send_ping();
+        void send_ping(); 
+        void send_savesync();
+        void update_save_info();
+        std::vector<std::string> find_rom_save_files(const std::string& path);
+        std::string sha1_save_info(const save_info& saveInfo);
+        std::string slurp(const std::string& file);
+        std::string slurp2(const std::string& file);
+        void replace_save_file(const save_info& save_data);
+
 };

--- a/NetplayInputPlugin/netplay_input_plugin.cpp
+++ b/NetplayInputPlugin/netplay_input_plugin.cpp
@@ -12,6 +12,13 @@
 using namespace std;
 
 #if defined(__cplusplus)
+string get_parent_directory(string dir) {
+    int index = dir.find_last_of("/\\");
+    if (index == dir.length() - 1)
+        dir = dir.substr(0, dir.length() - 1);
+    return dir.substr(0, dir.find_last_of("/\\"));
+}
+
 extern "C" {
 #endif
 
@@ -23,6 +30,9 @@ static shared_ptr<settings> my_settings;
 static shared_ptr<input_plugin> my_plugin;
 static shared_ptr<client> my_client;
 static string my_location;
+static string my_project64_location;
+static string my_saves_location;
+static string my_plugins_location;
 static array<bool, 4> port_already_visited;
 static rom_info rom;
 
@@ -56,6 +66,10 @@ void load() {
     GetModuleFileName(this_dll, my_location_array, MAX_PATH);
     wcsrchr(my_location_array, L'\\')[1] = 0;
     my_location = wstring_to_utf8(my_location_array);
+    
+    my_plugins_location = get_parent_directory(wstring_to_utf8(my_location_array));
+    my_project64_location = get_parent_directory(my_plugins_location).append("\\");
+    my_saves_location = my_project64_location.append("Save\\");
 
     my_settings = make_shared<settings>(my_location + "netplay_input_plugin.ini");
 
@@ -75,6 +89,7 @@ void unload() {
 
     if (my_client) {
         my_settings->set_name(my_client->get_name());
+        my_settings->set_favorite_server(my_client->get_favorite_server());
     }
 
     my_settings->save();
@@ -234,13 +249,15 @@ EXPORT void CALL ReadController ( int Control, BYTE * Command ) {
 EXPORT void CALL RomClosed (void) {
     load();
 
-    if (my_client) {
+    if (my_client) {        
         my_settings->set_name(my_client->get_name());
+        my_settings->set_favorite_server(my_client->get_favorite_server());
         my_client->post_close();
         my_client.reset();
     }
 
     if (my_plugin) {
+        my_plugin->controllers_initiated = false;
         my_plugin->RomClosed();
     }
 
@@ -259,9 +276,12 @@ EXPORT void CALL RomOpen (void) {
     }
 
     if (my_plugin) {
+
         my_client = make_shared<client>(make_shared<client_dialog>(this_dll, control_info.hMainWindow));
         my_client->set_name(my_settings->get_name());
         my_client->set_rom_info(rom);
+        my_client->set_save_info(my_saves_location);
+        my_client->set_favorite_server(my_settings->get_favorite_server());
         my_client->set_dst_controllers(control_info.Controls);
         my_client->load_public_server_list();
 

--- a/NetplayInputPlugin/packet.h
+++ b/NetplayInputPlugin/packet.h
@@ -37,6 +37,7 @@ public:
         return *this;
     }
 
+
     packet& transpose(size_t rows, size_t cols) {
         if (rows == 0 && cols == 0) {
             return *this;

--- a/NetplayInputPlugin/room.cpp
+++ b/NetplayInputPlugin/room.cpp
@@ -25,6 +25,35 @@ void room::close() {
     my_server->on_room_close(this);
 }
 
+void room::check_save_data() {
+    if (user_list.size() <= 1)
+        return;
+
+    std::array<string, 5> first_hashes;
+    bool run_once = true;
+    for (auto& user : user_list) {
+        if (run_once) {
+            for (int i = 0; i < user->info.saves.size(); i++) {
+                auto& save = user->info.saves[i];
+                first_hashes[i] = save.sha1_data;
+            }
+            run_once = false;
+        }
+
+        
+        for (int i = 0; i < user->info.saves.size(); i++) {
+            auto& save_data = user->info.saves[i];
+            auto& hash = first_hashes[i];
+            if (save_data.sha1_data != hash) {
+                send_error("Save data mismatch, you may desync in-game");
+                return;
+            }
+        }
+        
+    }
+    send_info("Save data is in sync!");
+}
+
 void room::on_user_join(user* user) {
     if (started) {
         user->send_error("Game is already in progress");
@@ -58,6 +87,8 @@ void room::on_user_join(user* user) {
     send_controllers();
 
     user->send(packet() << GOLF << golf);
+
+    check_save_data();
 }
 
 void room::on_user_quit(user* user) {

--- a/NetplayInputPlugin/room.h
+++ b/NetplayInputPlugin/room.h
@@ -35,7 +35,7 @@ class room: public std::enable_shared_from_this<room> {
         void set_lag(uint8_t lag, user* source);
         void send_latencies();
         void send_hia_input();
-
+        void check_save_data();
         const std::string id;
         server* my_server;
         std::vector<user*> user_map;

--- a/NetplayInputPlugin/server.cpp
+++ b/NetplayInputPlugin/server.cpp
@@ -99,7 +99,7 @@ void server::read() {
                     udp_socket.send_to(buffer(pong), udp_remote_endpoint, 0, error);
                     if (error) return;
                     break;
-                }
+                }               
             }
         }
         read();
@@ -114,9 +114,12 @@ void server::on_user_join(user* user, string room_id) {
     }
 
     if (rooms.find(room_id) == rooms.end()) {
-        rooms[room_id] = make_shared<room>(room_id, this, user->info.rom);
+        auto curr_room = make_shared<room>(room_id, this, user->info.rom);
+        rooms[room_id] = curr_room;
+        
         log("[" + room_id + "] " + user->info.name + " created room");
         log("[" + room_id + "] " + user->info.name + " set game to " + user->info.rom.to_string());
+        
         log_room_list();
     }
 

--- a/NetplayInputPlugin/settings.cpp
+++ b/NetplayInputPlugin/settings.cpp
@@ -13,6 +13,10 @@ settings::settings(const string& settings_path) : settings_path(settings_path) {
     wchar_t name[256];
     GetPrivateProfileString(L"user", L"name", L"Anonymous", name, 256, utf8_to_wstring(settings_path).c_str());
     this->name = wstring_to_utf8(name);
+
+    wchar_t favorite_server[256];
+    GetPrivateProfileString(L"server", L"favorite_server", L"<-- No Favorite Set -->", favorite_server, 256, utf8_to_wstring(settings_path).c_str());
+    this->favorite_server = wstring_to_utf8(favorite_server);
 }
 
 const string& settings::get_plugin_dll() const {
@@ -23,6 +27,11 @@ const string& settings::get_name() const {
     return name;
 }
 
+const string& settings::get_favorite_server() const {
+    return favorite_server;
+}
+
+
 void settings::set_plugin_dll(const string& plugin_dll) {
     this->plugin_dll = plugin_dll;
 }
@@ -31,7 +40,13 @@ void settings::set_name(const string& name) {
     this->name = name;
 }
 
+void settings::set_favorite_server(const string& favorite_server) {
+    this->favorite_server = favorite_server;
+}
+
+
 void settings::save() {
     WritePrivateProfileString(L"plugin", L"dll", utf8_to_wstring(plugin_dll).c_str(), utf8_to_wstring(settings_path).c_str());
     WritePrivateProfileString(L"user",   L"name", utf8_to_wstring(name).c_str(), utf8_to_wstring(settings_path).c_str());
+    WritePrivateProfileString(L"server", L"favorite_server", utf8_to_wstring(favorite_server).c_str(), utf8_to_wstring(settings_path).c_str());
 }

--- a/NetplayInputPlugin/settings.h
+++ b/NetplayInputPlugin/settings.h
@@ -7,8 +7,10 @@ class settings {
         settings(const std::string& settings_path);
         const std::string& get_name() const;
         const std::string& get_plugin_dll() const;
+        const std::string& get_favorite_server() const;
         void set_plugin_dll(const std::string& plugin_dll);
         void set_name(const std::string& name);
+        void set_favorite_server(const std::string& favorite_server);
         void save();
     protected:
     private:
@@ -17,4 +19,5 @@ class settings {
         std::string settings_path;
         std::string plugin_dll;
         std::string name;
+        std::string favorite_server;
 };

--- a/NetplayInputPlugin/stdafx.h
+++ b/NetplayInputPlugin/stdafx.h
@@ -21,16 +21,19 @@
 #include <future>
 #include <iomanip>
 #include <iostream>
+#include <fstream>
 #include <list>
 #include <map>
 #include <memory>
 #include <mutex>
 #include <random>
+#include <regex>
 #include <string>
 #include <thread>
 #include <unordered_map>
 #include <vector>
 #include <utility>
+
 
 #ifdef _WIN32
 #include <atlbase.h>

--- a/NetplayInputPlugin/user.h
+++ b/NetplayInputPlugin/user.h
@@ -24,6 +24,9 @@ class user : public connection {
         void send_protocol_version();
         void send_accept();
         void send_join(const user_info& name);
+        void send_save_info(uint32_t id, const std::array<save_info, 5>& saves);
+        void send_save_sync(const std::array<save_info, 5>& saves);
+
         void send_name(uint32_t id, const std::string& name);
         void send_ping();
         void send_quit(uint32_t id);


### PR DESCRIPTION
Hey I made a few modifications that I like to use with my friends, and wanted to share if you were interested. This pull request implements /savesync and /favorite.
- /savesync will take the commanding-player's save and sync it across all players in a room
- /savesync[playername] will sync the target player's save with the commanding player's save ([playername] will overwrite commanding player)
- /favorite will add a server/room to the server list
- /roomcheck checks if all saves are compatible (i meant to do more checks so it's kinda redundant as it stands)
- fixes incorrect game displaying if you load a rom, close the rom, then open a different one

This PR isn't really merge-ready because it contains some garbage in it (AQFartyBear is a joke amongst my friends), but I still wanted it to be available if you(or anyone else) was interested. 
- Save directory is found by assuming a standard installation and going up 2 parent directories from the module's path and forward 1 into a Save/ directory (This does not work on project64 2.4 because saves are in their own directories)
- save files get overwritten instead of moved/restored
- saves use a sha256sum from the client to verify integrity across the wire
- if i do anything weird in this pr, it's because this is literally the first C++ project I've ever done anything with nor am I familiar very with windows. This is 100% wine-compatible even with other windows users in a lobby. 

Building:
- introduces dirent and cryptopp which are statically linked (not sure how else to traverse directories or generate sha256sums)
- .\vcpkg install dirent:x86-windows-static 
- .\vcpkg install cryptopp:x86-windows-static
- requires vcpkg to be allowed to build static libraries

after that all should build as normal

If there's interest. I'd be open to cleaning it up and fixing it up. Again thanks for the plugin, love it!

Cheers